### PR TITLE
Use factory to construct settings builder.

### DIFF
--- a/external-maven-plugin/src/main/java/com/universalmediaserver/external/AbstractExternalDependencyMojo.java
+++ b/external-maven-plugin/src/main/java/com/universalmediaserver/external/AbstractExternalDependencyMojo.java
@@ -55,6 +55,7 @@ import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.DefaultSettingsBuilder;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
 import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
 import org.apache.maven.settings.building.SettingsBuilder;
 import org.apache.maven.settings.building.SettingsBuildingException;
@@ -633,11 +634,7 @@ public abstract class AbstractExternalDependencyMojo extends AbstractInstallMojo
 	 * 			The SettingsBuilder instance
 	 */
 	public SettingsBuilder getSettingsBuilder() {
-		DefaultSettingsBuilder settingsBuilder = new DefaultSettingsBuilder();
-		settingsBuilder.setSettingsReader(new DefaultSettingsReader());
-		settingsBuilder.setSettingsValidator(new DefaultSettingsValidator());
-		settingsBuilder.setSettingsWriter(new DefaultSettingsWriter());
-		return settingsBuilder;
+		return new DefaultSettingsBuilderFactory().newInstance();
 	}
 
 	/**


### PR DESCRIPTION
In Maven 3.6.2, the default constructor for DefaultSettingsBuilder no longer exists, because they added a non-default constructor.

The behavior removed in this patch is equivalent to the newInstance method from DefaultSettingsBuilderFactory. This allows the plugin to work on Maven 3.6.2.

I'm not sure if there's more "proper" way to get the DefaultSettingsBuilderFactory instance, but since it seems to have little to no state of its own this seems like a good enough change for now.